### PR TITLE
Fix `pnpm test` warning related to fumadocs.

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/nextjs.json",
+  "extends": "../../packages/tsconfig/nextjs.json",
   "compilerOptions": {
     "paths": {
       "@/*": ["./*"]


### PR DESCRIPTION
Before this fix, I would get the following warning when running `pnpm test` from the braintrust root directory:

```
source env.sh && pnpm test --filter "braintrustdata"

> braintrustdata@0.1.0 test /Users/manu/braintrust/braintrust/app
> npx vitest run

The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
[tsconfig-paths] An error occurred while parsing "/Users/manu/braintrust/braintrust/forked/fumadocs/apps/docs/tsconfig.json". See below for details. To disable this message, set the `ignoreConfigErrors` option to true.
TSConfckParseError: failed to resolve "extends":"tsconfig/nextjs.json" in /Users/manu/braintrust/braintrust/forked/fumadocs/apps/docs/tsconfig.json
    at resolveExtends (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/tsconfck@3.0.2_typescript@5.4.5/node_modules/tsconfck/src/parse.js:251:8)
    at parseExtends (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/tsconfck@3.0.2_typescript@5.4.5/node_modules/tsconfck/src/parse.js:186:24)
    ... 5 lines matching cause stack trace ...
    at async _createServer (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/vite@5.1.4_@types+node@18.19.3/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:64257:20)
    at async createViteServer (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/vitest@1.3.1_@types+node@18.19.3/node_modules/vitest/dist/vendor/cac.wWT9ELdg.js:10942:18)
    at async createVitest (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/vitest@1.3.1_@types+node@18.19.3/node_modules/vitest/dist/vendor/cac.wWT9ELdg.js:12185:18) {
  code: 'EXTENDS_RESOLVE',
  cause: Error: Cannot find module 'tsconfig/nextjs.json/tsconfig.json'
  Require stack:
  - /Users/manu/braintrust/braintrust/forked/fumadocs/apps/docs/tsconfig.json
      at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
      at Function.resolve (node:internal/modules/helpers:190:19)
      at resolveExtends (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/tsconfck@3.0.2_typescript@5.4.5/node_modules/tsconfck/src/parse.js:245:15)
      at parseExtends (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/tsconfck@3.0.2_typescript@5.4.5/node_modules/tsconfck/src/parse.js:186:24)
      at Module.parse (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/tsconfck@3.0.2_typescript@5.4.5/node_modules/tsconfck/src/parse.js:53:23)
      at async Promise.all (index 20)
      at async configResolved (/Users/manu/braintrust/braintrust/node_modules/.pnpm/vite-tsconfig-paths@4.3.1_typescript@5.4.5/node_modules/vite-tsconfig-paths/dist/index.js:134:9)
      at async Promise.all (index 0)
      at async resolveConfig (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/vite@5.1.4_@types+node@18.19.3/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:67889:5)
      at async _createServer (file:///Users/manu/braintrust/braintrust/node_modules/.pnpm/vite@5.1.4_@types+node@18.19.3/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:64257:20) {
    code: 'MODULE_NOT_FOUND',
    requireStack: [
      '/Users/manu/braintrust/braintrust/forked/fumadocs/apps/docs/tsconfig.json'
    ]
  },
  tsconfigFile: '/Users/manu/braintrust/braintrust/forked/fumadocs/apps/docs/tsconfig.json'
}
```

But if I change the path to point to an accurate relative path to the location of the `nextjs.json` file within the fumadocs repo, this error goes away.